### PR TITLE
Upgrade project to latest versions of Java, JaCoCo, Coveralls and TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
+---
 language: java
+dist: trusty
 jdk:
   - openjdk8
-  - openjdk9
+  - openjdk10
+  - openjdk11
+  - oraclejdk8
+  - oraclejdk9
+  - oraclejdk11
 after_success:
   - mvn clean test jacoco:report coveralls:report

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java-version>1.6</java-version>
+        <java-version>1.7</java-version>
 
         <oss-sonatype-url>https://oss.sonatype.org</oss-sonatype-url>
         <git-repo-ssh-url>git@github.com:marccarre/commons-testing.git</git-repo-ssh-url>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 
         <maven-compiler-plugin-version>3.2</maven-compiler-plugin-version>
         <maven-surefire-plugin-version>2.18</maven-surefire-plugin-version>
-        <jacoco-maven-plugin-version>0.7.2.201409121644</jacoco-maven-plugin-version>
+        <jacoco-maven-plugin-version>0.8.6</jacoco-maven-plugin-version>
         <coveralls-maven-plugin-version>4.3.0</coveralls-maven-plugin-version>
         <nexus-staging-maven-plugin-version>1.6.5</nexus-staging-maven-plugin-version>
         <maven-source-plugin-version>2.4</maven-source-plugin-version>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <maven-compiler-plugin-version>3.2</maven-compiler-plugin-version>
         <maven-surefire-plugin-version>2.18</maven-surefire-plugin-version>
         <jacoco-maven-plugin-version>0.7.2.201409121644</jacoco-maven-plugin-version>
-        <coveralls-maven-plugin-version>3.0.1</coveralls-maven-plugin-version>
+        <coveralls-maven-plugin-version>4.3.0</coveralls-maven-plugin-version>
         <nexus-staging-maven-plugin-version>1.6.5</nexus-staging-maven-plugin-version>
         <maven-source-plugin-version>2.4</maven-source-plugin-version>
         <maven-javadoc-plugin-version>2.10.1</maven-javadoc-plugin-version>

--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,13 @@
                     <groupId>org.eluder.coveralls</groupId>
                     <artifactId>coveralls-maven-plugin</artifactId>
                     <version>${coveralls-maven-plugin-version}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>javax.xml.bind</groupId>
+                            <artifactId>jaxb-api</artifactId>
+                            <version>2.2.4</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.sonatype.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,6 @@
         <junit-version>4.13.1</junit-version>
 
         <maven-compiler-plugin-version>3.2</maven-compiler-plugin-version>
-        <maven-surefire-plugin-version>2.18</maven-surefire-plugin-version>
         <jacoco-maven-plugin-version>0.8.6</jacoco-maven-plugin-version>
         <coveralls-maven-plugin-version>4.3.0</coveralls-maven-plugin-version>
         <nexus-staging-maven-plugin-version>1.6.5</nexus-staging-maven-plugin-version>
@@ -173,17 +172,6 @@
                 </configuration>
             </plugin>
 
-            <!-- Testing -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <argLine>-Xmx1024m</argLine>
-                    <!-- <parallel>both</parallel>
-                    <threadCount>8</threadCount> -->
-                </configuration>
-            </plugin>
-
             <!-- Code Coverage -->
             <plugin>
                 <groupId>org.jacoco</groupId>
@@ -218,11 +206,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven-compiler-plugin-version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>${maven-surefire-plugin-version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jacoco</groupId>


### PR DESCRIPTION
### Changelog

- Upgrade `maven-compiler-plugin`'s Java version from 1.6 to 1.7.
- Upgrade CI to please latest version of TravisCI.
- Upgrade Coveralls from v3.0.1 to v4.3.0.
- Upgrade JaCoCo from v0.7.2 to v0.8.6.
- Remove Surefire plugin, as conflicting with JaCoCo.
- Add missing JAXB dependency required by Coveralls in recent Java versions.